### PR TITLE
docs: add contributor guide and refresh readme

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,18 @@
+# Repository Guidelines
+
+## Project Structure & Module Organization
+This package uses the conventional `src/` layout: core modules live in `src/path_extract/`, where `cli.py` defines the Cyclopts-powered entry point exposed as the `pathex` script and `__init__.py` wires it for packaging. Documentation drafts sit alongside the code in `README.md` and `main.md`, and dependency state is pinned by `uv.lock`. Add new modules under `src/path_extract/` and keep exploratory notebooks or large assets outside the package tree.
+
+## Build, Test, and Development Commands
+- `uv sync` — create or update the local environment exactly as described by `pyproject.toml` and `uv.lock`.
+- `uv run pathex --help` — exercise the CLI wiring; extend subcommands here when you add new features.
+- `uv run python -m pytest` — execute the test suite (add `pytest` to the project’s optional dev dependencies before running if it is not yet installed).
+
+## Coding Style & Naming Conventions
+Target Python 3.13 features, keep 4-space indentation, and follow PEP 8 conventions for spacing and imports. Modules and functions should be lowercase `snake_case`; classes stay in `PascalCase`, and CLI command names should remain short and action-oriented (for example, `pathex extract`). Prefer expressive type hints and docstrings that clarify inputs, outputs, and side effects.
+
+## Testing Guidelines
+Place tests under a top-level `tests/` package mirroring the source layout (e.g., `tests/test_cli.py`). Write cases with `pytest`, name files and functions `test_*`, and cover new code paths, especially Cyclopts command handlers and data transformation logic. Aim for high branch coverage and include regression tests whenever you fix a bug; failing cases should accompany the fix in the same pull request.
+
+## Commit & Pull Request Guidelines
+Follow the existing Conventional Commit style observed in history (`feat:`, `chore:`, etc.), keeping summaries under 72 characters and scoping changes per commit. Pull requests should describe the motivation, outline significant code paths touched, list manual or automated checks performed (reference commands from the build section), and link related issues. Request at least one review before merging and update documentation or examples together with functional changes.

--- a/README.md
+++ b/README.md
@@ -1,11 +1,43 @@
-# PathEx: A pathology report entity extraction tool
+# PathEx: Pathology Report Entity Extraction
 
+PathEx streamlines the process of structuring pathology reports by extracting key clinical entities—diagnoses, specimen attributes, and supporting context—into consistent, analysis-ready data. The toolkit is packaged as a Cyclopts-powered command-line interface (CLI) so it can slot into existing data pipelines and automation workflows.
+
+## Highlights
+- Opinionated CLI foundation using [Cyclopts](https://github.com/jamesls/cyclopts) for ergonomic subcommand design.
+- Built on modern Python 3.13 and efficient data tooling such as Polars.
+- Ships with a reproducible environment managed by `uv` and a packaging-friendly `src/` layout.
+
+## Quick Start
+1. **Install prerequisites**
+   - Python 3.13+
+   - [`uv`](https://docs.astral.sh/uv/) package manager (`pip install uv` or download the binary)
+2. **Sync the environment**
+   ```bash
+   uv sync
+   ```
+3. **Run the CLI**
+   ```bash
+   uv run pathex --help
+   ```
+   Extend `src/path_extract/cli.py` with additional commands as extractor capabilities grow.
+
+## Project Layout
 ```
-Extracts relevant entities from pathology reports, such as diagnoses, specimen details, and clinical information.
-
-Utilizes natural language processing (NLP) techniques to identify and structure key data for downstream analysis.
-
-Designed to handle diverse report formats and terminology, providing standardized output for integration with other systems.
-
+path-extract/
+├── src/path_extract/        # Library and CLI entry points
+│   ├── __init__.py          # Exposes the Cyclopts App as `pathex`
+│   └── cli.py               # CLI command definitions
+├── README.md                # Project overview (this document)
+├── AGENTS.md                # Contributor quick-reference
+├── pyproject.toml           # Project metadata and dependencies
+└── uv.lock                  # Reproducible environment lockfile
 ```
- 
+Place new extractor modules under `src/path_extract/` and keep tests in a top-level `tests/` package that mirrors the source tree (e.g., `tests/test_cli.py`).
+
+## Development Workflow
+- **Environment**: `uv sync` installs runtime and development dependencies; rerun after updating `pyproject.toml`.
+- **Testing**: Add `pytest` to the optional dev dependencies and run with `uv run python -m pytest`. Commit failing tests alongside fixes.
+- **Formatting**: Follow PEP 8 with 4-space indentation and descriptive docstrings. Organize imports using `isort`/`ruff` if added.
+
+## Contributing
+Use Conventional Commits (`feat:`, `chore:`, `fix:`) for history clarity. Each pull request should outline the problem solved, summarize the approach, and list manual or automated checks performed (tests, CLI runs, etc.). Link related issues and include documentation updates whenever behavior changes.


### PR DESCRIPTION
## Summary
- add AGENTS.md contributor guide for maintainers
- rewrite README with setup, CLI usage, project layout, dev workflow

## Testing
- not run (docs only)
